### PR TITLE
optimize and fix typo

### DIFF
--- a/src/Command/StartCommand.php
+++ b/src/Command/StartCommand.php
@@ -36,7 +36,7 @@ class StartCommand extends Command
         $configs = $config->get('server');
         $serverFactory = new ServerFactory();
         $serverFactory->configure($configs);
-        $serverFactory->getServer()->start();
+        $serverFactory->start();
         return 1;
     }
 

--- a/src/Command/StartCommand.php
+++ b/src/Command/StartCommand.php
@@ -30,14 +30,13 @@ class StartCommand extends Command
         $this->setName('start')->setDescription('启动服务');
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output): int
+    protected function execute(InputInterface $input, OutputInterface $output)
     {
         $config = $this->config;
         $configs = $config->get('server');
         $serverFactory = new ServerFactory();
         $serverFactory->configure($configs);
         $serverFactory->start();
-        return 1;
     }
 
 

--- a/src/Server/Server.php
+++ b/src/Server/Server.php
@@ -3,7 +3,6 @@
 namespace Rebuild\Server;
 
 
-use Swoole\Coroutine\Server as SwooleCoServer;
 use Swoole\Server as SwooleServer;
 use Swoole\Http\Server as SwooelHttpServer;
 
@@ -14,11 +13,6 @@ class Server implements ServerInterface
      * @var SwooleServer
      */
     protected $server;
-
-    /**
-     * @var array
-     */
-    protected $onRequestCallbacks = [];
 
     public function init(array $config): ServerInterface
     {
@@ -43,10 +37,10 @@ class Server implements ServerInterface
 
     protected function registerSwooleEvents(array $callbacks)
     {
-        foreach ($callbacks as $swolleEvent => $callback) {
+        foreach ($callbacks as $swooleEvent => $callback) {
             [$class, $method] = $callback;
             $instance = new $class();
-            $this->server->on($swolleEvent, [$instance, $method]);
+            $this->server->on($swooleEvent, [$instance, $method]);
         }
     }
 }

--- a/src/Server/ServerFactory.php
+++ b/src/Server/ServerFactory.php
@@ -27,5 +27,9 @@ class ServerFactory
         return $this->server;
     }
 
+    public function start()
+    {
+        $this->getServer()->start();
+    }
 
 }


### PR DESCRIPTION
根据 hyperf 中的 【StartServer.php】文件的启动方法， 修改了 rebuild中的【StartCommand.php】中的启动方法。修改了 单词 拼写错误。